### PR TITLE
Fix "clear completed" button to actually work

### DIFF
--- a/js/controllers/todo.js
+++ b/js/controllers/todo.js
@@ -38,9 +38,10 @@ var app = app || {};
 
         // Remove all Todos where Completed == true
         this.clearCompleted = function() {
-            for(var i = 0; i < this.list.length; i++) {
-                if(this.list[i].completed())
-                    this.list.splice(i, 1)
+            for(var i = this.list.length - 1; i >= 0; i--) {
+                if (this.list[i].completed()) {
+                    this.list.splice(i, 1);
+                }
             }
         }
 


### PR DESCRIPTION
As it stands, the "clear completed" button fails to work as intended.  This is because the array is mutated during the traversal.  An item which immediately follows a completed item will not be checked.  The fix is to traverse the array backwards.
